### PR TITLE
Update check_code.py

### DIFF
--- a/scripts/check_code.py
+++ b/scripts/check_code.py
@@ -499,8 +499,8 @@ def find_cppcheck( cppcheck_bin, verbose = True ) :
                # Let the use know that we have CPPCHECK_HOME and where it is.
                TrickHLAMessage.status( 'CPPCHECK_HOME: ' + cppcheck_home )
 
-               # Form the cppcheck command based on CPPCHECK_HOME.
-               cppcheck_command = cppcheck_home + '/cppcheck'
+            # Form the cppcheck command based on CPPCHECK_HOME.
+            cppcheck_command = cppcheck_home + '/cppcheck'
 
          else :
             TrickHLAMessage.failure( 'CPPCHECK_HOME not found: ' + cppcheck_home )


### PR DESCRIPTION
fixed the following bug:
- if CPPCHECK_HOME environment variable is set and points to a valid directory, the cppcheck_command variable would only get set if verbose mode is true.